### PR TITLE
add formatting to Docusaurus app schematic

### DIFF
--- a/libs/docusaurus/README.md
+++ b/libs/docusaurus/README.md
@@ -49,6 +49,7 @@ nx run my-docs-app:build-docusaurus
 | ----------------- | ------- | ------------------------------------------ |
 | `--tags`          | -       | Tags to use for linting (comma-delimited). |
 | `--directory`     | 'apps'  | A directory where the project is placed.   |
+| `--skipFormat`    | false   | Skip formatting files.                     |
 
 ### Docusaurus server builder
 

--- a/libs/docusaurus/src/schematics/app/schema.d.ts
+++ b/libs/docusaurus/src/schematics/app/schema.d.ts
@@ -2,4 +2,5 @@ export interface AppSchematicSchema {
   name: string;
   tags?: string;
   directory?: string;
+  skipFormat: boolean;
 }

--- a/libs/docusaurus/src/schematics/app/schema.json
+++ b/libs/docusaurus/src/schematics/app/schema.json
@@ -22,6 +22,11 @@
       "type": "string",
       "description": "A directory where the project is placed",
       "alias": "d"
+    },
+    "skipFormat": {
+      "description": "Skip formatting files",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": ["name"]

--- a/libs/docusaurus/src/schematics/app/schematic.spec.ts
+++ b/libs/docusaurus/src/schematics/app/schematic.spec.ts
@@ -6,7 +6,7 @@ import { AppSchematicSchema } from './schema';
 
 describe('docusaurus schematic', () => {
   let appTree: Tree;
-  const options: AppSchematicSchema = { name: 'test' };
+  const options: AppSchematicSchema = { name: 'test', skipFormat: false };
 
   const testRunner = new SchematicTestRunner(
     '@nx-plus/docusaurus',
@@ -16,6 +16,7 @@ describe('docusaurus schematic', () => {
   beforeEach(() => {
     appTree = createEmptyWorkspace(Tree.empty());
     appTree.create('.gitignore', '');
+    appTree.create('.prettierignore', '');
   });
 
   describe('--directory', () => {


### PR DESCRIPTION
I tested this by running the Docusaurus app schematic with formatting and without formatting, and then checking formatting using `npm run format:check`.