### PR TITLE
add check for required outputPath option

### DIFF
--- a/libs/docusaurus/src/builders/build-docusaurus/builder.ts
+++ b/libs/docusaurus/src/builders/build-docusaurus/builder.ts
@@ -5,7 +5,7 @@ import {
 } from '@angular-devkit/architect';
 import { build } from '@docusaurus/core/lib';
 import { join, normalize } from '@angular-devkit/core';
-import { from, Observable } from 'rxjs';
+import { from, Observable, of } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { BuildDocusaurusBuilderSchema } from './schema';
 import { getProjectRoot } from '../../utils';
@@ -14,6 +14,11 @@ export function runBuilder(
   options: BuildDocusaurusBuilderSchema,
   context: BuilderContext
 ): Observable<BuilderOutput> {
+  if (!options.outputPath) {
+    context.logger.error('Invalid options, "outputPath" is required.');
+    return of({ success: false });
+  }
+
   return from(getProjectRoot(context)).pipe(
     switchMap(projectRoot =>
       from(


### PR DESCRIPTION
The `required` field doesn't work as expected in `schema.json`. Even when `outputPath` is provided a schema error is thrown saying it wasn't provided. That's why the check is in `builder.ts`.