### PR TITLE
fix windows path issue

### DIFF
--- a/libs/docusaurus/src/builders/build-docusaurus/builder.ts
+++ b/libs/docusaurus/src/builders/build-docusaurus/builder.ts
@@ -4,7 +4,7 @@ import {
   createBuilder
 } from '@angular-devkit/architect';
 import { build } from '@docusaurus/core/lib';
-import { join, normalize } from '@angular-devkit/core';
+import { join } from 'path';
 import { from, Observable, of } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { BuildDocusaurusBuilderSchema } from './schema';
@@ -24,7 +24,7 @@ export function runBuilder(
       from(
         build(projectRoot, {
           bundleAnalyzer: options.bundleAnalyzer,
-          outDir: join(normalize(context.workspaceRoot), options.outputPath),
+          outDir: join(context.workspaceRoot, options.outputPath),
           minify: options.minify
         })
       )

--- a/libs/docusaurus/src/utils.ts
+++ b/libs/docusaurus/src/utils.ts
@@ -1,9 +1,9 @@
 import { BuilderContext } from '@angular-devkit/architect';
-import { join, normalize } from '@angular-devkit/core';
+import { join } from 'path';
 
 export async function getProjectRoot(context: BuilderContext): Promise<string> {
   const projectMetadata = await context.getProjectMetadata(
     context.target.project
   );
-  return join(normalize(context.workspaceRoot), projectMetadata.root as string);
+  return join(context.workspaceRoot, projectMetadata.root as string);
 }


### PR DESCRIPTION
Mixing Angular's path utilities and the node 'path' package does not mesh well. On Windows, the drive was being appended twice i.e. "C:\\C\rest\of\the\path".

fixes #21