### PR TITLE
handle required options with JSON schemas and disallow unknown options

### DIFF
--- a/libs/vue-plugin/src/builders/browser/schema.d.ts
+++ b/libs/vue-plugin/src/builders/browser/schema.d.ts
@@ -8,7 +8,7 @@ export interface BrowserBuilderSchema extends JsonObject {
   skipClean: boolean;
   report: boolean;
   reportJson: boolean;
-  skipPlugins: string;
+  skipPlugins?: string;
   watch: boolean;
   index: string;
   main: string;

--- a/libs/vue-plugin/src/builders/browser/schema.json
+++ b/libs/vue-plugin/src/builders/browser/schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema",
   "$id": "https://json-schema.org/draft-07/schema",
   "title": "Browser builder",
   "description": "Build app",
@@ -94,7 +93,8 @@
       "enum": ["none", "all", "media", "bundles"]
     }
   },
-  "required": [],
+  "required": ["outputPath", "index", "main", "tsConfig"],
+  "additionalProperties": false,
   "definitions": {
     "assetPattern": {
       "oneOf": [

--- a/libs/vue-plugin/src/builders/dev-server/builder.ts
+++ b/libs/vue-plugin/src/builders/dev-server/builder.ts
@@ -58,6 +58,19 @@ export function runBuilder(
         modifyCachePaths(config, context);
         addFileReplacements(config, browserOptions, context);
         modifyFilenameHashing(config, browserOptions);
+
+        if (!options.watch) {
+          // There is no option to disable file watching in `webpack-dev-server`,
+          // but webpack's file watcher can be overriden.
+          config.plugin('vue-cli').use({
+            apply: compiler => {
+              compiler.hooks.afterEnvironment.tap('vue-cli', () => {
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                compiler.watchFileSystem = { watch: () => {} };
+              });
+            }
+          });
+        }
       }
     };
 

--- a/libs/vue-plugin/src/builders/dev-server/schema.d.ts
+++ b/libs/vue-plugin/src/builders/dev-server/schema.d.ts
@@ -4,11 +4,12 @@ export interface DevServerBuilderSchema extends JsonObject {
   open: boolean;
   copy: boolean;
   stdin: boolean;
-  mode: 'development' | 'production';
+  mode?: 'development' | 'production';
   host: string;
   port: number;
   https: boolean;
-  public: string;
-  skipPlugins: string;
+  public?: string;
+  skipPlugins?: string;
   buildTarget: string;
+  watch: boolean;
 }

--- a/libs/vue-plugin/src/builders/dev-server/schema.json
+++ b/libs/vue-plugin/src/builders/dev-server/schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema",
   "$id": "https://json-schema.org/draft-07/schema",
   "title": "DevServer builder",
   "description": "Start development server",
@@ -52,7 +51,13 @@
       "type": "string",
       "description": "Target to serve.",
       "pattern": "^[^:\\s]+:[^:\\s]+(:[^\\s]+)?$"
+    },
+    "watch": {
+      "type": "boolean",
+      "description": "Watch for changes.",
+      "default": true
     }
   },
-  "required": []
+  "required": ["buildTarget"],
+  "additionalProperties": false
 }


### PR DESCRIPTION
Each builder's required options are now validated by their JSON schema. Removing `$schema` made `required` work as expected. I'm not sure why and I didn't find the docs very helpful. I added `"additionalProperties": false` to each schema so that an error is thrown when an unknown option is passed, e.g. `--unknownOption`.

The `watch` option had to be added to the dev server builder because Nx's Cypress builder passes the watch option to the dev server builder, and it would fail because `"additionalProperties": false` was added to the dev server schema.

To complete testing I had to fix the browser builder not working in watch mode.