### PR TITLE
modify build and serve console output

### DIFF
--- a/libs/vue/src/utils.ts
+++ b/libs/vue/src/utils.ts
@@ -4,6 +4,9 @@ import { normalize, resolve, virtualFs } from '@angular-devkit/core';
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
 import { BrowserBuilderSchema } from './builders/browser/schema';
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { chalk } = require('@vue/cli-shared-utils');
+
 export async function getProjectRoot(context: BuilderContext): Promise<string> {
   const projectMetadata = await context.getProjectMetadata(
     context.target.project
@@ -42,4 +45,19 @@ export function getNormalizedAssetPatterns(
     normalize(projectRoot),
     projectSourceRoot === undefined ? undefined : normalize(projectSourceRoot)
   );
+}
+
+export function modifyChalkOutput(
+  method: string,
+  transform: (arg: string) => string
+) {
+  const originalChalkFn = chalk[method];
+  Object.defineProperty(chalk, method, {
+    get() {
+      const newChalkFn = (...args: string[]) =>
+        originalChalkFn(...args.map(transform));
+      Object.setPrototypeOf(newChalkFn, originalChalkFn);
+      return newChalkFn;
+    }
+  });
 }


### PR DESCRIPTION
Modified chalk over console log as it seemed less obtrusive (webpack has a dependency on chalk but I could not find any uses).