### PR TITLE
align builder options with Nx and remove unsupported options

### DIFF
--- a/libs/vue-plugin/src/builders/browser/builder.ts
+++ b/libs/vue-plugin/src/builders/browser/builder.ts
@@ -86,11 +86,11 @@ export function runBuilder(
         inlineOptions
       });
       const buildOptions = {
-        mode: options.mode,
+        mode: options.optimization ? 'production' : 'development',
         dest: undefined,
-        modern: options.modern,
-        'no-unsafe-inline': options.skipUnsafeInline,
-        'no-clean': options.skipClean,
+        modern: false,
+        'unsafe-inline': true,
+        clean: options.deleteOutputPath,
         report: options.report,
         'report-json': options.reportJson,
         'skip-plugins': options.skipPlugins,

--- a/libs/vue-plugin/src/builders/browser/schema.d.ts
+++ b/libs/vue-plugin/src/builders/browser/schema.d.ts
@@ -1,11 +1,9 @@
 import { JsonObject } from '@angular-devkit/core';
 
 export interface BrowserBuilderSchema extends JsonObject {
-  mode: 'development' | 'production';
+  optimization: boolean;
   outputPath: string;
-  modern: boolean;
-  skipUnsafeInline: boolean;
-  skipClean: boolean;
+  deleteOutputPath: boolean;
   report: boolean;
   reportJson: boolean;
   skipPlugins?: string;

--- a/libs/vue-plugin/src/builders/browser/schema.json
+++ b/libs/vue-plugin/src/builders/browser/schema.json
@@ -4,30 +4,19 @@
   "description": "Build app",
   "type": "object",
   "properties": {
-    "mode": {
-      "type": "string",
-      "enum": ["development", "production"],
-      "description": "Specify env mode (default: development).",
-      "default": "development"
+    "optimization": {
+      "type": "boolean",
+      "description": "Enables optimization of the build output.",
+      "default": false
     },
     "outputPath": {
       "type": "string",
       "description": "Specify output directory."
     },
-    "modern": {
+    "deleteOutputPath": {
       "type": "boolean",
-      "description": "Build app targeting modern browsers with auto fallback.",
-      "default": false
-    },
-    "skipUnsafeInline": {
-      "type": "boolean",
-      "description": "Build app without introducing inline scripts.",
-      "default": false
-    },
-    "skipClean": {
-      "type": "boolean",
-      "description": "Do not remove the dist directory before building the project.",
-      "default": false
+      "description": "Delete the output path before building.",
+      "default": true
     },
     "report": {
       "type": "boolean",

--- a/libs/vue-plugin/src/builders/dev-server/builder.ts
+++ b/libs/vue-plugin/src/builders/dev-server/builder.ts
@@ -24,7 +24,7 @@ const Service = require('@vue/cli-service/lib/Service');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { resolvePkg } = require('@vue/cli-shared-utils/lib/pkg');
 
-const devServerBuilderOverriddenKeys = ['mode', 'skipPlugins'];
+const devServerBuilderOverriddenKeys = ['optimization', 'skipPlugins'];
 
 export function runBuilder(
   options: DevServerBuilderSchema,
@@ -36,7 +36,7 @@ export function runBuilder(
     browserOptions: BrowserBuilderSchema;
     inlineOptions;
   }> {
-    const browserTarget = targetFromTargetString(options.buildTarget);
+    const browserTarget = targetFromTargetString(options.browserTarget);
     const rawBrowserOptions = await context.getTargetOptions(browserTarget);
     const overrides = Object.keys(options)
       .filter(
@@ -101,11 +101,11 @@ export function runBuilder(
               open: options.open,
               copy: options.copy,
               stdin: options.stdin,
-              mode: browserOptions.mode,
+              mode: browserOptions.optimization ? 'production' : 'development',
               host: options.host,
               port: options.port,
-              https: options.https,
-              public: options.public,
+              https: options.ssl,
+              public: options.publicHost,
               'skip-plugins': browserOptions.skipPlugins
             },
             ['serve']

--- a/libs/vue-plugin/src/builders/dev-server/schema.d.ts
+++ b/libs/vue-plugin/src/builders/dev-server/schema.d.ts
@@ -4,12 +4,12 @@ export interface DevServerBuilderSchema extends JsonObject {
   open: boolean;
   copy: boolean;
   stdin: boolean;
-  mode?: 'development' | 'production';
+  optimization?: boolean;
   host: string;
   port: number;
-  https: boolean;
-  public?: string;
+  ssl: boolean;
+  publicHost?: string;
   skipPlugins?: string;
-  buildTarget: string;
+  browserTarget: string;
   watch: boolean;
 }

--- a/libs/vue-plugin/src/builders/dev-server/schema.json
+++ b/libs/vue-plugin/src/builders/dev-server/schema.json
@@ -19,10 +19,9 @@
       "description": "Close when stdin ends.",
       "default": false
     },
-    "mode": {
-      "type": "string",
-      "enum": ["development", "production"],
-      "description": "Specify env mode (default: development)."
+    "optimization": {
+      "type": "boolean",
+      "description": "Enables optimization of the build output."
     },
     "host": {
       "type": "string",
@@ -34,12 +33,12 @@
       "description": "Specify port (default: 4200).",
       "default": 4200
     },
-    "https": {
+    "ssl": {
       "type": "boolean",
-      "description": "Use https (default: false).",
+      "description": "Serve using HTTPS.",
       "default": false
     },
-    "public": {
+    "publicHost": {
       "type": "string",
       "description": "Specify the public network URL for the HMR client."
     },
@@ -47,7 +46,7 @@
       "type": "string",
       "description": "Comma-separated list of plugin names to skip for this run."
     },
-    "buildTarget": {
+    "browserTarget": {
       "type": "string",
       "description": "Target to serve.",
       "pattern": "^[^:\\s]+:[^:\\s]+(:[^\\s]+)?$"
@@ -58,6 +57,6 @@
       "default": true
     }
   },
-  "required": ["buildTarget"],
+  "required": ["browserTarget"],
   "additionalProperties": false
 }

--- a/libs/vue-plugin/src/schematics/application/schematic.spec.ts
+++ b/libs/vue-plugin/src/schematics/application/schematic.spec.ts
@@ -52,16 +52,16 @@ describe('application schematic', () => {
           with: 'apps/my-app/src/environments/environment.prod.ts'
         }
       ],
-      mode: 'production',
+      optimization: true,
       outputHashing: 'all',
       extractCss: true
     });
     expect(serve.builder).toBe('@nx-plus/vue-plugin:dev-server');
     expect(serve.options).toEqual({
-      buildTarget: 'my-app:build'
+      browserTarget: 'my-app:build'
     });
     expect(serve.configurations.production).toEqual({
-      buildTarget: 'my-app:build:production'
+      browserTarget: 'my-app:build:production'
     });
     expect(lint.builder).toBe('@nrwl/linter:lint');
     expect(test.builder).toBe('@nrwl/jest:jest');
@@ -304,10 +304,10 @@ describe('application schematic', () => {
         }
       ]);
       expect(serve.options).toEqual({
-        buildTarget: 'subdir-my-app:build'
+        browserTarget: 'subdir-my-app:build'
       });
       expect(serve.configurations.production).toEqual({
-        buildTarget: 'subdir-my-app:build:production'
+        browserTarget: 'subdir-my-app:build:production'
       });
     });
 

--- a/libs/vue-plugin/src/schematics/application/schematic.ts
+++ b/libs/vue-plugin/src/schematics/application/schematic.ts
@@ -220,7 +220,7 @@ export default function(options: ApplicationSchematicSchema): Rule {
                 with: `${normalizedOptions.projectRoot}/src/environments/environment.prod.ts`
               }
             ],
-            mode: 'production',
+            optimization: true,
             outputHashing: 'all',
             extractCss: true
           }
@@ -230,11 +230,11 @@ export default function(options: ApplicationSchematicSchema): Rule {
         name: 'serve',
         builder: '@nx-plus/vue-plugin:dev-server',
         options: {
-          buildTarget: `${normalizedOptions.projectName}:build`
+          browserTarget: `${normalizedOptions.projectName}:build`
         },
         configurations: {
           production: {
-            buildTarget: `${normalizedOptions.projectName}:build:production`
+            browserTarget: `${normalizedOptions.projectName}:build:production`
           }
         }
       });


### PR DESCRIPTION
The options `modern` and `no-unsafe-inline` were removed because they apply only to modern mode, which we don't support at this time. The options `no-clean` and `no-unsafe-inline` were renamed because it seems options prefixed with "no-" are treated special, similar to Angular CLI. That seems to be a common CLI design pattern.