### PR TITLE
add copy assets to serve builder

### DIFF
--- a/apps/vue-plugin-e2e/tests/vue-plugin.test.ts
+++ b/apps/vue-plugin-e2e/tests/vue-plugin.test.ts
@@ -36,7 +36,7 @@ describe('vue-plugin e2e', () => {
     ).not.toThrow();
 
     done();
-  }, 200000);
+  }, 300000);
 
   describe('--directory subdir', () => {
     it('should create and build app', async done => {
@@ -58,6 +58,6 @@ describe('vue-plugin e2e', () => {
       ).not.toThrow();
 
       done();
-    }, 200000);
+    }, 300000);
   });
 });

--- a/libs/vue-plugin/src/builders/browser/builder.ts
+++ b/libs/vue-plugin/src/builders/browser/builder.ts
@@ -3,18 +3,15 @@ import {
   BuilderOutput,
   createBuilder
 } from '@angular-devkit/architect';
-import { normalizeAssetPatterns } from '@angular-devkit/build-angular/src/utils';
-import {
-  getSystemPath,
-  join,
-  normalize,
-  virtualFs
-} from '@angular-devkit/core';
-import { NodeJsSyncHost } from '@angular-devkit/core/node';
+import { getSystemPath, join, normalize } from '@angular-devkit/core';
 import { from, Observable } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { BrowserBuilderSchema } from './schema';
-import { getProjectRoot, getProjectSourceRoot } from '../../utils';
+import {
+  getNormalizedAssetPatterns,
+  getProjectRoot,
+  getProjectSourceRoot
+} from '../../utils';
 import {
   addFileReplacements,
   modifyCachePaths,
@@ -40,15 +37,12 @@ export function runBuilder(
   }> {
     const projectRoot = await getProjectRoot(context);
     const projectSourceRoot = await getProjectSourceRoot(context);
-    // https://github.com/angular/angular-cli/blob/v9.1.0/packages/angular_devkit/build_angular/src/browser/index.ts#L574
-    const normalizedAssetPatterns = normalizeAssetPatterns(
-      options.assets,
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
-      new virtualFs.SyncDelegateHost(new NodeJsSyncHost()),
-      normalize(context.workspaceRoot),
-      normalize(projectRoot),
-      projectSourceRoot === undefined ? undefined : normalize(projectSourceRoot)
+
+    const normalizedAssetPatterns = getNormalizedAssetPatterns(
+      options,
+      context,
+      projectRoot,
+      projectSourceRoot
     );
 
     const inlineOptions = {

--- a/libs/vue-plugin/src/utils.ts
+++ b/libs/vue-plugin/src/utils.ts
@@ -1,5 +1,8 @@
 import { BuilderContext } from '@angular-devkit/architect';
-import { normalize, resolve } from '@angular-devkit/core';
+import { normalizeAssetPatterns } from '@angular-devkit/build-angular/src/utils';
+import { normalize, resolve, virtualFs } from '@angular-devkit/core';
+import { NodeJsSyncHost } from '@angular-devkit/core/node';
+import { BrowserBuilderSchema } from './builders/browser/schema';
 
 export async function getProjectRoot(context: BuilderContext): Promise<string> {
   const projectMetadata = await context.getProjectMetadata(
@@ -21,4 +24,22 @@ export async function getProjectSourceRoot(
   return projectSourceRoot
     ? resolve(normalize(context.workspaceRoot), normalize(projectSourceRoot))
     : undefined;
+}
+
+export function getNormalizedAssetPatterns(
+  options: BrowserBuilderSchema,
+  context: BuilderContext,
+  projectRoot: string,
+  projectSourceRoot: string
+) {
+  // https://github.com/angular/angular-cli/blob/v9.1.0/packages/angular_devkit/build_angular/src/browser/index.ts#L574
+  return normalizeAssetPatterns(
+    options.assets,
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
+    new virtualFs.SyncDelegateHost(new NodeJsSyncHost()),
+    normalize(context.workspaceRoot),
+    normalize(projectRoot),
+    projectSourceRoot === undefined ? undefined : normalize(projectSourceRoot)
+  );
 }


### PR DESCRIPTION
This PR adds the copying of assets the same as how the browser builder handles assets. This behavior is in line with how the [Angular CLI](https://github.com/angular/angular-cli/blob/9d333498c6cf762b840f45b2e744c4dcf742b186/packages/angular_devkit/build_angular/src/dev-server/index.ts#L120) handles static assets when serving an application. The [Vue CLI](https://github.com/vuejs/vue-cli/blob/36f961e43dc76705878659247b563e2af83138ce/packages/%40vue/cli-service/lib/commands/serve.js#L179) handles assets via the `contentBase` property, but we need to support all assets copied from the `assets` configuration option which might contain assets from more than one directory.