### PR TITLE
Fix reference to <root>/tsconfig.base.json in generated vue apps for nx 10

### DIFF
--- a/libs/vue/src/schematics/application/files/tsconfig.json.template
+++ b/libs/vue/src/schematics/application/files/tsconfig.json.template
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.json",
+  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
   "compilerOptions": {
     "jsx": "preserve",
     "esModuleInterop": true,


### PR DESCRIPTION
Fixes the issue described in #43 where Vue app refuses to start due to incorrect tsconfig extends reference.

In the log below, I am trying to serve vue-app which is failing because tsconfig.json no longer exists. References need to update to point to tsconfig.base.json instead

```
 ERROR  Failed to compile with 2 errors                                                                                                                                                                                                                                                                           12:49:01 AM

 error  in /home/jon/foo/apps/vue-app/tsconfig.app.json

[tsl] ERROR
      TS5083: Cannot read file '/home/jon/foo/tsconfig.json'.
```