### PR TITLE
add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -1,0 +1,33 @@
+---
+name: "🐞 Bug Report"
+about: Report Current Behavior that is believed to be unintentional or unexpected.
+labels: "bug"
+
+---
+
+<!-- Please do your best to fill out all of the sections below! -->
+
+## Current Behavior
+<!-- What is the behavior that currently you experience? -->
+
+## Expected Behavior
+<!-- What is the behavior that you expect to happen? -->
+<!-- Is this a regression? .i.e Did this used to be the behavior at one point?  -->
+
+## Steps to Reproduce
+<!-- Help us help you by making it easy for us to reproduce your issue! -->
+
+<!-- Please provide a minimal Github repo -->
+<!-- At the very least, provide as much detail as possible to help us reproduce the issue -->
+
+<!-- Remove this line -->
+This issue may not be prioritized if details are not provided to help us reproduce the issue.
+
+### Failure Logs
+<!-- Please include any relevant log snippets or files here. -->
+
+### Environment
+<!-- It's important for us to know the context in which you experience this behavior! -->
+Plugin name and version: <!-- Replace with name + version -->
+
+<!-- Please paste the result of `nx report` below! -->

--- a/.github/ISSUE_TEMPLATE/2-feature.md
+++ b/.github/ISSUE_TEMPLATE/2-feature.md
@@ -1,0 +1,20 @@
+---
+name: "\U0001F680 Feature Request"
+about: Request Behavior that does not currently exist in Nx
+labels: "enhancement"
+
+---
+
+<!-- Please do your best to fill out all of the sections below! -->
+
+## Description
+<!-- What is the behavior that you would like to see introduced? -->
+
+## Motivation
+<!-- Why do you believe this behavior would be beneficial? -->
+
+## Suggested Implementation
+<!-- How do you imagine this might work? -->
+
+## Alternate Implementations
+<!-- How else do you imagine this might work? -->

--- a/.github/ISSUE_TEMPLATE/3-discussion.md
+++ b/.github/ISSUE_TEMPLATE/3-discussion.md
@@ -1,0 +1,10 @@
+---
+name: "💡  Discussion"
+about: "Start a thread to discuss an idea"
+
+---
+
+<!-- Please do your best to fill out all of the sections below! -->
+
+## Description
+<!-- What would you like to discuss? -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 
 /dist
 /coverage
+/.github


### PR DESCRIPTION
Copy and paste from [Nx](https://github.com/nrwl/nx/tree/master/.github/ISSUE_TEMPLATE). I'm not ashamed about it. It makes sense that we have the same issue templates.