### PR TITLE
throw an error if Vue CLI options are configured in package.json or vue.config.js

### DIFF
--- a/libs/vue/src/builders/browser/builder.ts
+++ b/libs/vue/src/builders/browser/builder.ts
@@ -3,11 +3,15 @@ import {
   BuilderOutput,
   createBuilder
 } from '@angular-devkit/architect';
-import { getSystemPath, join, normalize } from '@angular-devkit/core';
+import { getSystemPath, join, normalize, Path } from '@angular-devkit/core';
 import { from, Observable } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { BrowserBuilderSchema } from './schema';
-import { getProjectRoot, modifyChalkOutput } from '../../utils';
+import {
+  checkUnsupportedConfig,
+  getProjectRoot,
+  modifyChalkOutput,
+} from '../../utils';
 import {
   modifyCachePaths,
   modifyEntryPoint,
@@ -26,7 +30,7 @@ export function runBuilder(
   context: BuilderContext
 ): Observable<BuilderOutput> {
   async function setup(): Promise<{
-    projectRoot: string;
+    projectRoot: Path;
     inlineOptions;
   }> {
     const projectRoot = await getProjectRoot(context);
@@ -67,6 +71,8 @@ export function runBuilder(
 
   return from(setup()).pipe(
     switchMap(({ projectRoot, inlineOptions }) => {
+      checkUnsupportedConfig(context, projectRoot);
+
       const service = new Service(projectRoot, {
         pkg: resolvePkg(context.workspaceRoot),
         inlineOptions

--- a/libs/vue/src/builders/dev-server/builder.ts
+++ b/libs/vue/src/builders/dev-server/builder.ts
@@ -4,13 +4,17 @@ import {
   createBuilder,
   targetFromTargetString
 } from '@angular-devkit/architect';
-import { JsonObject } from '@angular-devkit/core';
+import { JsonObject, Path } from '@angular-devkit/core';
 import { cliCommand } from '@nrwl/workspace/src/core/file-utils';
 import { from, Observable } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { DevServerBuilderSchema } from './schema';
 import { BrowserBuilderSchema } from '../browser/schema';
-import { getProjectRoot, modifyChalkOutput } from '../../utils';
+import {
+  checkUnsupportedConfig,
+  getProjectRoot,
+  modifyChalkOutput,
+} from '../../utils';
 import {
   modifyCachePaths,
   modifyEntryPoint,
@@ -51,7 +55,7 @@ export function runBuilder(
 
   // https://github.com/angular/angular-cli/blob/v9.1.0/packages/angular_devkit/build_angular/src/dev-server/index.ts#L133
   async function setup(): Promise<{
-    projectRoot: string;
+    projectRoot: Path;
     browserOptions: BrowserBuilderSchema;
     inlineOptions;
   }> {
@@ -122,6 +126,8 @@ export function runBuilder(
 
   return from(setup()).pipe(
     switchMap(({ projectRoot, browserOptions, inlineOptions }) => {
+      checkUnsupportedConfig(context, projectRoot);
+
       const service = new Service(projectRoot, {
         pkg: resolvePkg(context.workspaceRoot),
         inlineOptions

--- a/libs/vue/src/utils.ts
+++ b/libs/vue/src/utils.ts
@@ -1,10 +1,17 @@
 import { BuilderContext } from '@angular-devkit/architect';
-import { normalize, resolve } from '@angular-devkit/core';
+import {
+  join,
+  normalize,
+  Path,
+  resolve,
+  virtualFs,
+} from '@angular-devkit/core';
+import { NodeJsSyncHost } from '@angular-devkit/core/node';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { chalk } = require('@vue/cli-shared-utils');
 
-export async function getProjectRoot(context: BuilderContext): Promise<string> {
+export async function getProjectRoot(context: BuilderContext): Promise<Path> {
   const projectMetadata = await context.getProjectMetadata(
     context.target.project
   );
@@ -39,4 +46,30 @@ export function modifyChalkOutput(
       return newChalkFn;
     }
   });
+}
+
+export function checkUnsupportedConfig(
+  context: BuilderContext,
+  projectRoot: Path
+): void {
+  const host = new virtualFs.SyncDelegateHost(new NodeJsSyncHost());
+  const packageJson = JSON.parse(
+    virtualFs.fileBufferToString(
+      host.read(join(normalize(context.workspaceRoot), 'package.json'))
+    )
+  );
+  const vueConfigExists =
+    host.exists(join(projectRoot, 'vue.config.js')) ||
+    host.exists(join(projectRoot, 'vue.config.cjs'));
+  const workspaceFileName = host.exists(
+    join(normalize(context.workspaceRoot), 'workspace.json')
+  )
+    ? 'workspace.json'
+    : 'angular.json';
+
+  if (packageJson.vue || vueConfigExists) {
+    throw new Error(
+      `You must specify vue-cli config options in '${workspaceFileName}'.`
+    );
+  }
 }


### PR DESCRIPTION
I tested this by running `serve` and `build` for a generated app with `"vue": {}` in `package.json`. I also ran those commands with no changes in `package.json`, but with a `vue.config.js` added to the generated app.