### PR TITLE
fix public folder not being copied on windows

### DIFF
--- a/libs/vue/src/builders/browser/builder.ts
+++ b/libs/vue/src/builders/browser/builder.ts
@@ -73,7 +73,7 @@ export function runBuilder(
     switchMap(({ projectRoot, inlineOptions }) => {
       checkUnsupportedConfig(context, projectRoot);
 
-      const service = new Service(projectRoot, {
+      const service = new Service(getSystemPath(projectRoot), {
         pkg: resolvePkg(context.workspaceRoot),
         inlineOptions,
       });

--- a/libs/vue/src/builders/dev-server/builder.ts
+++ b/libs/vue/src/builders/dev-server/builder.ts
@@ -4,7 +4,7 @@ import {
   createBuilder,
   targetFromTargetString,
 } from '@angular-devkit/architect';
-import { JsonObject, Path } from '@angular-devkit/core';
+import { getSystemPath, JsonObject, Path } from '@angular-devkit/core';
 import { cliCommand } from '@nrwl/workspace/src/core/file-utils';
 import { from, Observable } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
@@ -128,7 +128,7 @@ export function runBuilder(
     switchMap(({ projectRoot, browserOptions, inlineOptions }) => {
       checkUnsupportedConfig(context, projectRoot);
 
-      const service = new Service(projectRoot, {
+      const service = new Service(getSystemPath(projectRoot), {
         pkg: resolvePkg(context.workspaceRoot),
         inlineOptions,
       });

--- a/libs/vue/src/builders/library/builder.ts
+++ b/libs/vue/src/builders/library/builder.ts
@@ -68,7 +68,7 @@ export function runBuilder(
     switchMap(({ projectRoot, inlineOptions }) => {
       checkUnsupportedConfig(context, projectRoot);
 
-      const service = new Service(projectRoot, {
+      const service = new Service(getSystemPath(projectRoot), {
         pkg: resolvePkg(context.workspaceRoot),
         inlineOptions,
       });


### PR DESCRIPTION
## Current Behavior
`public` folder is not being copied on Windows

## Expected Behavior
`public` folder will be copied.

## More Info
The vue-cli resolves the public directory with `path.resolve`. On windows machines, the path we were providing the vue-cli as the project root was a normalized path (`/C/path/to/project`), which was not being resolved correctly.

Fixes #84
Could be related to #82