### PR TITLE
Add vue configure webpack support

### DIFF
--- a/libs/vue/src/builders/browser/builder.ts
+++ b/libs/vue/src/builders/browser/builder.ts
@@ -11,6 +11,7 @@ import {
   checkUnsupportedConfig,
   getProjectRoot,
   modifyChalkOutput,
+  resolveConfigureWebpack,
 } from '../../utils';
 import {
   modifyCachePaths,
@@ -34,6 +35,7 @@ export function runBuilder(
     inlineOptions;
   }> {
     const projectRoot = await getProjectRoot(context);
+    const configureWebpack = resolveConfigureWebpack(projectRoot);
 
     const inlineOptions = {
       chainWebpack: (config) => {
@@ -47,6 +49,7 @@ export function runBuilder(
       filenameHashing: options.filenameHashing,
       productionSourceMap: options.productionSourceMap,
       css: options.css,
+      configureWebpack,
     };
 
     return {

--- a/libs/vue/src/builders/dev-server/builder.ts
+++ b/libs/vue/src/builders/dev-server/builder.ts
@@ -14,6 +14,7 @@ import {
   checkUnsupportedConfig,
   getProjectRoot,
   modifyChalkOutput,
+  resolveConfigureWebpack,
 } from '../../utils';
 import {
   modifyCachePaths,
@@ -75,6 +76,7 @@ export function runBuilder(
     >({ ...rawBrowserOptions, ...overrides }, browserName);
 
     const projectRoot = await getProjectRoot(context);
+    const configureWebpack = resolveConfigureWebpack(projectRoot);
 
     const inlineOptions = {
       chainWebpack: (config) => {
@@ -100,6 +102,7 @@ export function runBuilder(
       publicPath: browserOptions.publicPath,
       filenameHashing: browserOptions.filenameHashing,
       css: browserOptions.css,
+      configureWebpack,
       devServer: options.devServer,
     };
 

--- a/libs/vue/src/builders/library/builder.ts
+++ b/libs/vue/src/builders/library/builder.ts
@@ -11,6 +11,7 @@ import {
   checkUnsupportedConfig,
   getProjectRoot,
   modifyChalkOutput,
+  resolveConfigureWebpack,
 } from '../../utils';
 import {
   modifyCachePaths,
@@ -33,6 +34,7 @@ export function runBuilder(
     inlineOptions;
   }> {
     const projectRoot = await getProjectRoot(context);
+    const configureWebpack = resolveConfigureWebpack(projectRoot);
 
     const inlineOptions = {
       chainWebpack: (config) => {
@@ -42,6 +44,7 @@ export function runBuilder(
         modifyCopyAssets(config, options, context, projectRoot);
       },
       css: options.css,
+      configureWebpack,
     };
 
     return {

--- a/libs/vue/src/schematics/application/files/configure-webpack.js.template
+++ b/libs/vue/src/schematics/application/files/configure-webpack.js.template
@@ -1,0 +1,3 @@
+module.exports = (config) => {
+
+}

--- a/libs/vue/src/schematics/library/files/configure-webpack.js.template
+++ b/libs/vue/src/schematics/library/files/configure-webpack.js.template
@@ -1,0 +1,3 @@
+module.exports = (config) => {
+
+}

--- a/libs/vue/src/schematics/library/schematic.ts
+++ b/libs/vue/src/schematics/library/schematic.ts
@@ -77,6 +77,9 @@ function addFiles(options: NormalizedSchema): Rule {
       options.unitTestRunner === 'none'
         ? filter((file) => file !== '/tests/unit/example.spec.ts')
         : noop(),
+      options.publishable
+        ? noop()
+        : filter((file) => file !== '/configure-webpack.js'),
       move(options.projectRoot),
     ])
   );

--- a/libs/vue/src/utils.ts
+++ b/libs/vue/src/utils.ts
@@ -1,5 +1,6 @@
 import { BuilderContext } from '@angular-devkit/architect';
 import {
+  getSystemPath,
   join,
   normalize,
   Path,
@@ -60,4 +61,14 @@ export function checkUnsupportedConfig(
       `You must specify vue-cli config options in '${workspaceFileName}'.`
     );
   }
+}
+
+export function resolveConfigureWebpack(projectRoot: string) {
+  const pathToWebpack = join(normalize(projectRoot), 'configure-webpack.js');
+
+  const host = new virtualFs.SyncDelegateHost(new NodeJsSyncHost());
+
+  return host.exists(pathToWebpack)
+    ? require(getSystemPath(pathToWebpack))
+    : {};
 }


### PR DESCRIPTION
## Current Behavior
No support for `configureWebpack` like you would have with the vue cli's `vue.config.js`.

## Expected Behavior
Support for `configureWebpack` using a `...config.js` file.

## Related Issue(s)
Fixes #62 
