### PR TITLE
Update to support Vue 3 build

### DIFF
--- a/libs/vue/src/webpack.ts
+++ b/libs/vue/src/webpack.ts
@@ -1,5 +1,6 @@
 import { BuilderContext } from '@angular-devkit/architect';
 import { getSystemPath, join, normalize, Path } from '@angular-devkit/core';
+import {loadModule, semver} from '@vue/cli-shared-utils';
 import { BrowserBuilderSchema } from './builders/browser/schema';
 import { LibraryBuilderSchema } from './builders/library/schema';
 
@@ -51,7 +52,11 @@ export function modifyTsConfigPaths(
       return loaderOptions;
     });
   config.plugin('fork-ts-checker').tap((args) => {
-    args[0].tsconfig = tsConfigPath;
+    const vue = loadModule('vue', getSystemPath(normalize(context.workspaceRoot)));
+    const isVue3 = (vue && semver.major(vue.version) === 3);
+    if (!isVue3) {
+      args[0].tsconfig = tsConfigPath;
+    }
     return args;
   });
 }


### PR DESCRIPTION
## Current Behavior
With Vue 3 builds, there is an error:
```
An unhandled exception occurred: Invalid configuration object. ForkTsCheckerWebpackPlugin has been initialized using a configuration object that does not match the API schema.
 - configuration has an unknown property 'tsconfig'. These properties are valid:
   object { async?, typescript?, eslint?, formatter?, issue?, logger? }
```

## Expected Behavior
Vue 3 projects build as expected.

## Related Issue(s)

Fixes #97


This might not fix all related issues, but it does address one that we found.  Namely that the latest @vue-cli has updated to use fork-typescript-checker v5 and that new version requires different parameters.  I did a basic change using the approach seen here: https://github.com/vuejs/vue-cli/commit/1aaa59264235b83cb1e2700ab2cf3aa04b40c907