### PR TITLE
add vue 3 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run: yarn affected:test --all
       - run:
           command: yarn affected:e2e --all
-          no_output_timeout: 30m
+          no_output_timeout: 40m
   affected:
     docker:
       - image: cypress/base:12
@@ -27,7 +27,7 @@ jobs:
       - run: yarn affected:test --base origin/master --head HEAD
       - run:
           command: yarn affected:e2e --base origin/master --head HEAD
-          no_output_timeout: 30m
+          no_output_timeout: 40m
 
 workflows:
   version: 2
@@ -36,10 +36,10 @@ workflows:
       - all:
           filters:
             branches:
-              only: 
+              only:
                 - master
       - affected:
           filters:
             branches:
-              ignore: 
+              ignore:
                 - master

--- a/apps/vue-e2e/jest.config.js
+++ b/apps/vue-e2e/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
   displayName: 'vue-e2e',
   preset: '../../jest.preset.js',
   coverageDirectory: '../../coverage/apps/vue-e2e',
+  maxWorkers: 1,
 };

--- a/apps/vue-e2e/tests/utils.ts
+++ b/apps/vue-e2e/tests/utils.ts
@@ -1,0 +1,96 @@
+import { tags } from '@angular-devkit/core';
+import {
+  checkFilesExist,
+  runNxCommandAsync,
+  tmpProjPath,
+} from '@nrwl/nx-plugin/testing';
+import * as cp from 'child_process';
+
+export async function testGeneratedApp(
+  appName: string,
+  options: {
+    lint: boolean;
+    test: boolean;
+    e2e: boolean;
+    build: boolean;
+    buildProd: boolean;
+  }
+): Promise<void> {
+  if (options.lint) {
+    const lintResult = await runNxCommandAsync(`lint ${appName}`);
+    expect(lintResult.stdout).toContain('All files pass linting.');
+  }
+
+  if (options.test) {
+    const testResult = await runNxCommandAsync(`test ${appName}`);
+    expect(testResult.stderr).toContain(tags.stripIndent`
+      Test Suites: 1 passed, 1 total
+      Tests:       1 passed, 1 total
+      Snapshots:   0 total
+    `);
+  }
+
+  if (options.e2e) {
+    const e2eResult = await runNxCommandAsync(`e2e ${appName}-e2e --headless`);
+    expect(e2eResult.stdout).toContain('All specs passed!');
+  }
+
+  if (options.build) {
+    const buildResult = await runNxCommandAsync(`build ${appName}`);
+    expect(buildResult.stdout).toContain('Build complete.');
+    expect(() =>
+      checkFilesExist(
+        `dist/apps/${appName}/index.html`,
+        `dist/apps/${appName}/favicon.ico`,
+        `dist/apps/${appName}/js/app.js`,
+        `dist/apps/${appName}/img/logo.png`
+      )
+    ).not.toThrow();
+  }
+
+  if (options.buildProd) {
+    const buildResult = await runNxProdCommandAsync(
+      `build ${appName} --prod --filenameHashing false`
+    );
+    expect(buildResult.stdout).toContain('Build complete.');
+    expect(() =>
+      checkFilesExist(
+        `dist/apps/${appName}/index.html`,
+        `dist/apps/${appName}/favicon.ico`,
+        `dist/apps/${appName}/js/app.js`,
+        `dist/apps/${appName}/js/app.js.map`,
+        `dist/apps/${appName}/js/chunk-vendors.js`,
+        `dist/apps/${appName}/js/chunk-vendors.js.map`,
+        `dist/apps/${appName}/img/logo.png`,
+        `dist/apps/${appName}/css/app.css`
+      )
+    ).not.toThrow();
+  }
+}
+
+// Vue CLI requires `NODE_ENV` be set to `production` to produce
+// a production build. Jest sets `NODE_ENV` to `test` by default.
+// This function is very similar to `runCommandAsync`.
+// https://github.com/nrwl/nx/blob/9.5.1/packages/nx-plugin/src/utils/testing-utils/async-commands.ts#L10
+export function runNxProdCommandAsync(
+  command: string
+): Promise<{
+  stdout: string;
+  stderr: string;
+}> {
+  return new Promise((resolve, reject) => {
+    cp.exec(
+      `node ./node_modules/@nrwl/cli/bin/nx.js ${command}`,
+      {
+        cwd: tmpProjPath(),
+        env: { ...process.env, NODE_ENV: 'production' },
+      },
+      (err, stdout, stderr) => {
+        if (err) {
+          reject(err);
+        }
+        resolve({ stdout, stderr });
+      }
+    );
+  });
+}

--- a/apps/vue-e2e/tests/vue-3.test.ts
+++ b/apps/vue-e2e/tests/vue-3.test.ts
@@ -1,0 +1,203 @@
+import { tags } from '@angular-devkit/core';
+import {
+  checkFilesExist,
+  ensureNxProject,
+  runNxCommandAsync,
+  uniq,
+  updateFile,
+} from '@nrwl/nx-plugin/testing';
+import { runNxProdCommandAsync, testGeneratedApp } from './utils';
+
+describe('vue 3 e2e', () => {
+  describe('app', () => {
+    it('should generate app', async (done) => {
+      const appName = uniq('app');
+      ensureNxProject('@nx-plus/vue', 'dist/libs/vue');
+      await runNxCommandAsync(
+        `generate @nx-plus/vue:app ${appName} --vueVersion 3`
+      );
+
+      await testGeneratedApp(appName, {
+        lint: true,
+        test: true,
+        e2e: true,
+        build: true,
+        buildProd: true,
+      });
+
+      done();
+    }, 300000);
+
+    describe('--routing', () => {
+      it('should generate app with routing', async (done) => {
+        const appName = uniq('app');
+        ensureNxProject('@nx-plus/vue', 'dist/libs/vue');
+        await runNxCommandAsync(
+          `generate @nx-plus/vue:app ${appName} --vueVersion 3 --routing`
+        );
+
+        await testGeneratedApp(appName, {
+          lint: true,
+          test: false,
+          e2e: true,
+          build: true,
+          buildProd: true,
+        });
+
+        expect(() =>
+          checkFilesExist(
+            `dist/apps/${appName}/js/about.js`,
+            `dist/apps/${appName}/js/about.js.map`
+          )
+        ).not.toThrow();
+
+        done();
+      }, 300000);
+    });
+
+    describe('vuex', () => {
+      it('should generate app and add vuex', async (done) => {
+        const appName = uniq('app');
+        ensureNxProject('@nx-plus/vue', 'dist/libs/vue');
+        await runNxCommandAsync(
+          `generate @nx-plus/vue:app ${appName} --vueVersion 3`
+        );
+        await runNxCommandAsync(`generate @nx-plus/vue:vuex ${appName}`);
+
+        await testGeneratedApp(appName, {
+          lint: true,
+          test: false,
+          e2e: false,
+          build: true,
+          buildProd: true,
+        });
+
+        done();
+      }, 300000);
+    });
+
+    it('should generate app with routing and add vuex', async (done) => {
+      const appName = uniq('app');
+      ensureNxProject('@nx-plus/vue', 'dist/libs/vue');
+      await runNxCommandAsync(
+        `generate @nx-plus/vue:app ${appName} --vueVersion 3 --routing`
+      );
+      await runNxCommandAsync(`generate @nx-plus/vue:vuex ${appName}`);
+
+      await testGeneratedApp(appName, {
+        lint: true,
+        test: false,
+        e2e: true,
+        build: true,
+        buildProd: true,
+      });
+
+      expect(() =>
+        checkFilesExist(
+          `dist/apps/${appName}/js/about.js`,
+          `dist/apps/${appName}/js/about.js.map`
+        )
+      ).not.toThrow();
+
+      done();
+    }, 300000);
+
+    it('should report lint error in App.vue', async (done) => {
+      const appName = uniq('app');
+      ensureNxProject('@nx-plus/vue', 'dist/libs/vue');
+      await runNxCommandAsync(
+        `generate @nx-plus/vue:app ${appName} --vueVersion 3`
+      );
+
+      updateFile(
+        `apps/${appName}/src/App.vue`,
+        '<script lang="ts">{}</script>'
+      );
+
+      const result = await runNxCommandAsync(`lint ${appName}`, {
+        silenceError: true,
+      });
+      expect(result.stderr).toContain('Lint errors found in the listed files.');
+
+      done();
+    }, 300000);
+  });
+
+  describe('library', () => {
+    it('should generate lib', async (done) => {
+      const lib = uniq('lib');
+      ensureNxProject('@nx-plus/vue', 'dist/libs/vue');
+      await runNxCommandAsync(
+        `generate @nx-plus/vue:lib ${lib} --vueVersion 3`
+      );
+
+      const lintResult = await runNxCommandAsync(`lint ${lib}`);
+      expect(lintResult.stdout).toContain('All files pass linting.');
+
+      const testResult = await runNxCommandAsync(`test ${lib}`);
+      expect(testResult.stderr).toContain(tags.stripIndent`
+      Test Suites: 1 passed, 1 total
+      Tests:       1 passed, 1 total
+      Snapshots:   0 total
+    `);
+
+      done();
+    }, 300000);
+
+    it('should generate publishable lib', async (done) => {
+      const lib = uniq('lib');
+      ensureNxProject('@nx-plus/vue', 'dist/libs/vue');
+      await runNxCommandAsync(
+        `generate @nx-plus/vue:lib ${lib} --vueVersion 3 --publishable`
+      );
+
+      let buildResult = await runNxProdCommandAsync(`build ${lib}`);
+      expect(buildResult.stdout).toContain('Compiled successfully');
+      expect(() =>
+        checkFilesExist(
+          `dist/libs/${lib}/demo.html`,
+          `dist/libs/${lib}/${lib}.common.js`,
+          `dist/libs/${lib}/${lib}.common.js.map`,
+          `dist/libs/${lib}/${lib}.umd.js`,
+          `dist/libs/${lib}/${lib}.umd.js.map`,
+          `dist/libs/${lib}/${lib}.umd.min.js`,
+          `dist/libs/${lib}/${lib}.umd.min.js.map`,
+          `dist/libs/${lib}/package.json`,
+          `dist/libs/${lib}/README.md`
+        )
+      ).not.toThrow();
+
+      buildResult = await runNxProdCommandAsync(`build ${lib} --name new-name`);
+      expect(() =>
+        checkFilesExist(
+          `dist/libs/${lib}/new-name.common.js`,
+          `dist/libs/${lib}/new-name.common.js.map`,
+          `dist/libs/${lib}/new-name.umd.js`,
+          `dist/libs/${lib}/new-name.umd.js.map`,
+          `dist/libs/${lib}/new-name.umd.min.js`,
+          `dist/libs/${lib}/new-name.umd.min.js.map`
+        )
+      ).not.toThrow();
+
+      buildResult = await runNxProdCommandAsync(
+        `build ${lib} --formats commonjs`
+      );
+      expect(() =>
+        checkFilesExist(
+          `dist/libs/${lib}/${lib}.common.js`,
+          `dist/libs/${lib}/${lib}.common.js.map`
+        )
+      ).not.toThrow();
+      expect(() =>
+        checkFilesExist(
+          `dist/libs/${lib}/${lib}.umd.js`,
+          `dist/libs/${lib}/${lib}.umd.js.map`,
+          `dist/libs/${lib}/${lib}.umd.min.js`,
+          `dist/libs/${lib}/${lib}.umd.min.js.map`
+        )
+      ).toThrow();
+
+      done();
+    }, 300000);
+  });
+});

--- a/libs/vue/README.md
+++ b/libs/vue/README.md
@@ -68,15 +68,16 @@ nx serve my-app
 | --------- | --------------------- |
 | `<name>`  | The name of your app. |
 
-| Options            | Default   | Description                                    |
-| ------------------ | --------- | ---------------------------------------------- |
-| `--tags`           | -         | Tags to use for linting (comma-delimited).     |
-| `--directory`      | `apps`    | A directory where the project is placed.       |
-| `--style`          | `css`     | The file extension to be used for style files. |
-| `--unitTestRunner` | `jest`    | Test runner to use for unit tests.             |
-| `--e2eTestRunner`  | `cypress` | Test runner to use for end to end (e2e) tests. |
-| `--routing`        | `false`   | Generate routing configuration.                |
-| `--skipFormat`     | `false`   | Skip formatting files.                         |
+| Options            | Default   | Description                                                    |
+| ------------------ | --------- | -------------------------------------------------------------- |
+| `--tags`           | -         | Tags to use for linting (comma-delimited).                     |
+| `--directory`      | `apps`    | A directory where the project is placed.                       |
+| `--style`          | `css`     | The file extension to be used for style files.                 |
+| `--unitTestRunner` | `jest`    | Test runner to use for unit tests.                             |
+| `--e2eTestRunner`  | `cypress` | Test runner to use for end to end (e2e) tests.                 |
+| `--routing`        | `false`   | Generate routing configuration.                                |
+| `--vueVersion`     | `2`       | The version of Vue.js that you want to start the project with. |
+| `--skipFormat`     | `false`   | Skip formatting files.                                         |
 
 ### Vuex
 
@@ -98,14 +99,15 @@ nx serve my-app
 | --------- | ------------------------- |
 | `<name>`  | The name of your library. |
 
-| Options            | Default | Description                                             |
-| ------------------ | ------- | ------------------------------------------------------- |
-| `--tags`           | -       | Tags to use for linting (comma-delimited).              |
-| `--directory`      | `libs`  | A directory where the project is placed.                |
-| `--unitTestRunner` | `jest`  | Test runner to use for unit tests.                      |
-| `--skipFormat`     | `false` | Skip formatting files.                                  |
-| `--skipTsConfig`   | `false` | Do not update tsconfig.json for development experience. |
-| `--publishable`    | `false` | Create a buildable library.                             |
+| Options            | Default | Description                                                    |
+| ------------------ | ------- | -------------------------------------------------------------- |
+| `--tags`           | -       | Tags to use for linting (comma-delimited).                     |
+| `--directory`      | `libs`  | A directory where the project is placed.                       |
+| `--unitTestRunner` | `jest`  | Test runner to use for unit tests.                             |
+| `--skipFormat`     | `false` | Skip formatting files.                                         |
+| `--skipTsConfig`   | `false` | Do not update tsconfig.json for development experience.        |
+| `--vueVersion`     | `2`     | The version of Vue.js that you want to start the project with. |
+| `--publishable`    | `false` | Create a buildable library.                                    |
 
 ## Builders (i.e. task runners)
 

--- a/libs/vue/src/schematics/application/files/src/App.vue.template
+++ b/libs/vue/src/schematics/application/files/src/App.vue.template
@@ -1,5 +1,5 @@
-<template>
-  <div id="app"><% if (routing) { %>
+<template><% if (!isVue3) { %>
+  <div id="app"><% } %><% if (routing) { %>
     <div id="nav">
       <router-link to="/">Home</router-link> |
       <router-link to="/about">About</router-link>
@@ -7,14 +7,14 @@
     <router-view /><% } else { %>
     <img alt="Vue logo" src="./assets/logo.png" />
     <HelloWorld msg="Welcome to Your Vue.js + TypeScript App" /><% } %>
-  </div>
+  <% if (!isVue3) { %></div><% } %>
 </template><% if (!routing) { %>
 
 <script lang="ts">
-import Vue from 'vue';
+import <% if (isVue3) { %>{ defineComponent }<% } else { %>Vue<% } %> from 'vue';
 import HelloWorld from './components/HelloWorld.vue';
 
-export default Vue.extend({
+export default <% if (isVue3) { %>defineComponent<% } else { %>Vue.extend<% } %>({
   name: 'App',
   components: {
     HelloWorld

--- a/libs/vue/src/schematics/application/files/src/components/HelloWorld.vue.template
+++ b/libs/vue/src/schematics/application/files/src/components/HelloWorld.vue.template
@@ -79,9 +79,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import <% if (isVue3) { %>{ defineComponent }<% } else { %>Vue<% } %> from 'vue';
 
-export default Vue.extend({
+export default <% if (isVue3) { %>defineComponent<% } else { %>Vue.extend<% } %>({
   name: 'HelloWorld',
   props: {
     msg: String

--- a/libs/vue/src/schematics/application/files/src/main.ts.template
+++ b/libs/vue/src/schematics/application/files/src/main.ts.template
@@ -1,10 +1,12 @@
-import Vue from 'vue';
+import <% if (isVue3) { %>{ createApp }<% } else { %>Vue<% } %> from 'vue';
 import App from './App.vue';<% if (routing) { %>
-import router from './router';<% } %>
+import router from './router';<% } %><% if (!isVue3) { %>
 
-Vue.config.productionTip = false;
+Vue.config.productionTip = false;<% } %>
 
-new Vue({<% if (routing) { %>
+<% if (isVue3) { %>createApp(App)<% if (routing) { %>
+  .use(router)<% } %>
+  .mount('#app');<% } else { %>new Vue({<% if (routing) { %>
   router,<% } %>
   render: h => h(App)
-}).$mount('#app');
+}).$mount('#app');<% } %>

--- a/libs/vue/src/schematics/application/files/src/router/index.ts.template
+++ b/libs/vue/src/schematics/application/files/src/router/index.ts.template
@@ -1,10 +1,10 @@
-import Vue from 'vue';
-import VueRouter, { RouteConfig } from 'vue-router';
-import Home from '../views/Home.vue';
+<% if (!isVue3) { %>import Vue from 'vue';<% } %>
+import <% if (isVue3) { %>{ createRouter, createWebHistory, RouteRecordRaw }<% } else { %>VueRouter, { RouteConfig }<% } %> from 'vue-router';
+import Home from '../views/Home.vue';<% if (!isVue3) { %>
 
-Vue.use(VueRouter);
+Vue.use(VueRouter);<% } %>
 
-const routes: Array<RouteConfig> = [
+const routes: Array<<% if (isVue3) { %>RouteRecordRaw<% } else { %>RouteConfig<% } %>> = [
   {
     path: '/',
     name: 'Home',
@@ -21,10 +21,13 @@ const routes: Array<RouteConfig> = [
   }
 ];
 
-const router = new VueRouter({
+const router = <% if (isVue3) { %>createRouter({
+  history: createWebHistory(process.env.BASE_URL),
+  routes
+});<% } else { %>new VueRouter({
   mode: 'history',
   base: process.env.BASE_URL,
   routes
-});
+});<% } %>
 
 export default router;

--- a/libs/vue/src/schematics/application/files/src/shims-vue.d.ts.template
+++ b/libs/vue/src/schematics/application/files/src/shims-vue.d.ts.template
@@ -1,4 +1,8 @@
-declare module '*.vue' {
+declare module '*.vue' {<% if (isVue3) { %>
+  import type { DefineComponent } from 'vue';
+  // eslint-disable-next-line
+  const component: DefineComponent<{}, {}, any>;
+  export default component;<% } else { %>
   import Vue from 'vue';
-  export default Vue;
+  export default Vue;<% } %>
 }

--- a/libs/vue/src/schematics/application/files/src/views/Home.vue.template
+++ b/libs/vue/src/schematics/application/files/src/views/Home.vue.template
@@ -6,12 +6,13 @@
 </template>
 
 <script>
+import <% if (isVue3) { %>{ defineComponent }<% } else { %>Vue<% } %> from 'vue';
 import HelloWorld from '../components/HelloWorld.vue';
 
-export default {
+export default <% if (isVue3) { %>defineComponent<% } else { %>Vue.extend<% } %>({
   name: 'Home',
   components: {
     HelloWorld
   }
-};
+});
 </script>

--- a/libs/vue/src/schematics/application/files/tests/unit/example.spec.ts.template
+++ b/libs/vue/src/schematics/application/files/tests/unit/example.spec.ts.template
@@ -4,8 +4,9 @@ import HelloWorld from '../../src/components/HelloWorld.vue';
 describe('HelloWorld.vue', () => {
   it('renders props.msg when passed', () => {
     const msg = 'new message';
-    const wrapper = shallowMount(HelloWorld, {
-      propsData: { msg }
+    const wrapper = shallowMount(HelloWorld, {<% if (isVue3) { %>
+      props<% } else { %>
+      propsData<% } %>: { msg }
     });
     expect(wrapper.text()).toMatch(msg);
   });

--- a/libs/vue/src/schematics/application/schema.d.ts
+++ b/libs/vue/src/schematics/application/schema.d.ts
@@ -6,5 +6,6 @@ export interface ApplicationSchematicSchema {
   unitTestRunner: 'jest' | 'none';
   e2eTestRunner: 'cypress' | 'none';
   routing: boolean;
+  vueVersion: number;
   skipFormat: boolean;
 }

--- a/libs/vue/src/schematics/application/schema.json
+++ b/libs/vue/src/schematics/application/schema.json
@@ -65,6 +65,19 @@
       "x-prompt": "Would you like to configure routing for this application?",
       "default": false
     },
+    "vueVersion": {
+      "description": "The version of Vue.js that you want to start the project with.",
+      "type": "number",
+      "default": 2,
+      "x-prompt": {
+        "message": "Which version of Vue.js would you like to use?",
+        "type": "list",
+        "items": [
+          { "value": 2, "label": "2.x" },
+          { "value": 3, "label": "3.x" }
+        ]
+      }
+    },
     "skipFormat": {
       "type": "boolean",
       "description": "Skip formatting files",

--- a/libs/vue/src/schematics/application/schematic.spec.ts
+++ b/libs/vue/src/schematics/application/schematic.spec.ts
@@ -14,6 +14,7 @@ describe('application schematic', () => {
     e2eTestRunner: 'cypress',
     routing: false,
     style: 'css',
+    vueVersion: 2,
     skipFormat: false,
   };
 

--- a/libs/vue/src/schematics/library/files/src/lib/HelloWorld.vue.template
+++ b/libs/vue/src/schematics/library/files/src/lib/HelloWorld.vue.template
@@ -3,9 +3,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import <% if (isVue3) { %>{ defineComponent }<% } else { %>Vue<% } %> from 'vue';
 
-export default Vue.extend({
+export default <% if (isVue3) { %>defineComponent<% } else { %>Vue.extend<% } %>({
   name: 'HelloWorld',
 });
 </script>

--- a/libs/vue/src/schematics/library/files/src/shims-vue.d.ts.template
+++ b/libs/vue/src/schematics/library/files/src/shims-vue.d.ts.template
@@ -1,4 +1,8 @@
-declare module '*.vue' {
+declare module '*.vue' {<% if (isVue3) { %>
+  import type { DefineComponent } from 'vue';
+  // eslint-disable-next-line
+  const component: DefineComponent<{}, {}, any>;
+  export default component;<% } else { %>
   import Vue from 'vue';
-  export default Vue;
+  export default Vue;<% } %>
 }

--- a/libs/vue/src/schematics/library/schema.d.ts
+++ b/libs/vue/src/schematics/library/schema.d.ts
@@ -6,4 +6,5 @@ export interface LibrarySchematicSchema {
   tags?: string;
   unitTestRunner: 'jest' | 'none';
   publishable: boolean;
+  vueVersion: number;
 }

--- a/libs/vue/src/schematics/library/schema.json
+++ b/libs/vue/src/schematics/library/schema.json
@@ -41,6 +41,19 @@
       "type": "boolean",
       "default": false,
       "description": "Create a buildable library."
+    },
+    "vueVersion": {
+      "description": "The version of Vue.js that you want to start the project with.",
+      "type": "number",
+      "default": 2,
+      "x-prompt": {
+        "message": "Which version of Vue.js would you like to use?",
+        "type": "list",
+        "items": [
+          { "value": 2, "label": "2.x" },
+          { "value": 3, "label": "3.x" }
+        ]
+      }
     }
   },
   "required": ["name"],

--- a/libs/vue/src/schematics/library/schematic.spec.ts
+++ b/libs/vue/src/schematics/library/schematic.spec.ts
@@ -12,6 +12,7 @@ describe('library schematic', () => {
     unitTestRunner: 'jest',
     skipFormat: false,
     publishable: false,
+    vueVersion: 2,
     skipTsConfig: false,
   };
 

--- a/libs/vue/src/schematics/vuex/schematic.spec.ts
+++ b/libs/vue/src/schematics/vuex/schematic.spec.ts
@@ -7,6 +7,9 @@ import { join } from 'path';
 
 import { VuexSchematicSchema } from './schema';
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const sharedUtils = require('@vue/cli-shared-utils');
+
 describe('vuex schematic', () => {
   let appTree: Tree;
   const options: VuexSchematicSchema = { project: 'my-app', skipFormat: false };
@@ -16,14 +19,19 @@ describe('vuex schematic', () => {
     join(__dirname, '../../../collection.json')
   );
 
-  beforeEach(async () => {
+  beforeEach(() => {
     appTree = createEmptyWorkspace(Tree.empty());
+  });
+
+  sharedUtils.loadModule = jest.fn();
+
+  it('should generate Vuex configuration for Vue 2', async () => {
+    sharedUtils.loadModule.mockReturnValue({ version: '2.0.0' });
+
     appTree = await testRunner
       .runSchematicAsync('app', { name: 'my-app' }, appTree)
       .toPromise();
-  });
 
-  it('should generate Vuex configuration', async () => {
     const tree = await testRunner
       .runSchematicAsync('vuex', options, appTree)
       .toPromise();
@@ -41,5 +49,26 @@ describe('vuex schematic', () => {
         render: (h) => h(App),
       }).$mount('#app');
     `);
+  });
+
+  it('should generate Vuex configuration for Vue 3', async () => {
+    sharedUtils.loadModule.mockReturnValue({ version: '3.0.0' });
+
+    appTree = await testRunner
+      .runSchematicAsync('app', { name: 'my-app', vueVersion: 3 }, appTree)
+      .toPromise();
+
+    const tree = await testRunner
+      .runSchematicAsync('vuex', options, appTree)
+      .toPromise();
+
+    const packageJson = readJsonInTree(tree, 'package.json');
+    expect(packageJson.dependencies['vuex']).toBeDefined();
+
+    expect(tree.exists('apps/my-app/src/store/index.ts')).toBeTruthy();
+
+    const main = tree.readContent('apps/my-app/src/main.ts');
+    expect(main).toContain("import store from './store';");
+    expect(main).toContain("createApp(App).use(store).mount('#app');");
   });
 });


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
Vue 3 isn't supported.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Vue 3 is supported.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Closes #69 

Helpful Vue CLI PRs:

- [feat: allow choosing vue version on creation (and in presets)](https://github.com/vuejs/vue-cli/pull/5637/files)
- [feat: detect and compile Vue 3 projects](https://github.com/vuejs/vue-cli/pull/5570/files)
- [fix: use fork-ts-checker-webpack-plugin v5 for vue 3 type checking](https://github.com/vuejs/vue-cli/pull/5722/files)
- [fix: update the `.vue` file shim for Vue 3](https://github.com/vuejs/vue-cli/pull/5903/files)