### PR TITLE
fix schematic throwing error with non-standard name

### DIFF
--- a/libs/docusaurus/src/schematics/app/schematic.ts
+++ b/libs/docusaurus/src/schematics/app/schematic.ts
@@ -51,6 +51,7 @@ function normalizeOptions(
 
   return {
     ...options,
+    name,
     projectName,
     projectRoot,
     projectDirectory,

--- a/libs/nuxt/src/schematics/application/schematic.ts
+++ b/libs/nuxt/src/schematics/application/schematic.ts
@@ -58,6 +58,7 @@ function normalizeOptions(
 
   return {
     ...options,
+    name,
     projectName,
     projectRoot,
     projectDirectory,

--- a/libs/vue/src/schematics/application/schematic.ts
+++ b/libs/vue/src/schematics/application/schematic.ts
@@ -60,6 +60,7 @@ function normalizeOptions(
 
   return {
     ...options,
+    name,
     projectName,
     projectRoot,
     projectDirectory,

--- a/libs/vue/src/schematics/library/schematic.ts
+++ b/libs/vue/src/schematics/library/schematic.ts
@@ -64,6 +64,7 @@ function normalizeOptions(
 
   return {
     ...options,
+    name,
     projectName,
     projectRoot,
     projectDirectory,


### PR DESCRIPTION
## Current Behavior
Vue/Nuxt schematic throws when name contains an underscore (`nx g @nx-plus/vue:app my_app`)

## Expected Behavior
`nx g @nx-plus/vue:app my_app` works

## Related Issue(s)
#108

Fixes #
#108