### PR TITLE
fix(nuxt): remove universal mode on config

### DIFF
--- a/libs/nuxt/src/schematics/application/files/nuxt.config.js.template
+++ b/libs/nuxt/src/schematics/application/files/nuxt.config.js.template
@@ -1,10 +1,5 @@
 export default {
   /*
-   ** Nuxt rendering mode
-   ** See https://nuxtjs.org/api/configuration-mode
-   */
-  mode: 'universal',
-  /*
    ** Nuxt target
    ** See https://nuxtjs.org/api/configuration-target
    */


### PR DESCRIPTION
## Current Behavior
After generating a new nuxt app when you run a nuxt application you get a warning that [universal mode is no longer supported](https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-mode).


## Expected Behavior
The deprecation warning is no longer visible.