### PR TITLE
pin vue-jest version

### DIFF
--- a/libs/vue/src/schematics/application/schematic.ts
+++ b/libs/vue/src/schematics/application/schematic.ts
@@ -234,7 +234,7 @@ function addJest(options: NormalizedSchema): Rule {
         'babel-core': '^7.0.0-bridge.0',
         'jest-serializer-vue': '^2.0.2',
         'jest-transform-stub': '^2.0.0',
-        'vue-jest': options.isVue3 ? '^5.0.0-0' : '^3.0.5',
+        'vue-jest': options.isVue3 ? '5.0.0-alpha.7' : '^3.0.5',
       },
       true
     ),

--- a/libs/vue/src/schematics/library/schematic.ts
+++ b/libs/vue/src/schematics/library/schematic.ts
@@ -164,7 +164,7 @@ function addJest(options: NormalizedSchema): Rule {
         'babel-core': '^7.0.0-bridge.0',
         'jest-serializer-vue': '^2.0.2',
         'jest-transform-stub': '^2.0.0',
-        'vue-jest': options.isVue3 ? '^5.0.0-0' : '^3.0.5',
+        'vue-jest': options.isVue3 ? '5.0.0-alpha.7' : '^3.0.5',
       },
       true
     ),


### PR DESCRIPTION
## Current Behavior
New projects using Vue 3 + Jest don't work.
![Screen Shot 2021-01-20 at 9 37 08 PM](https://user-images.githubusercontent.com/25158820/105276802-ca604d00-5b67-11eb-8f86-8137a2db559f.png)


## Expected Behavior
New projects using Vue 3 + Jest will work.

New version of vue-jest ([v5.0.0-alpha.8](https://github.com/vuejs/vue-jest/commit/5af29e97043e526db83aebdcaa3ce0856e9d715c)) looks for a `tsconfig.json` at the root of the project. Since nx has switched to using `tsconfig.base.json`, vue-jest fails to find the config and errors out. Pinning the version will work for now, but a PR in vue-jest should be made to fix this issue.