### PR TITLE
increase test timeout because several master builds in a row have failed because of a timed out test

### DIFF
--- a/libs/vue/jest.config.js
+++ b/libs/vue/jest.config.js
@@ -7,4 +7,5 @@ module.exports = {
   coverageDirectory: '../../coverage/libs/vue',
   globals: { 'ts-jest': { tsConfig: '<rootDir>/tsconfig.spec.json' } },
   displayName: 'vue',
+  testTimeout: 10000,
 };


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/ZachJW34/nx-plus?branch=master

I cannot reproduce the timeout, but that's to no surprise since the tests run ~3x as fast on my machine.