### PR TITLE
fix nuxt linting if @nx-plus/vue is installed

### DIFF
--- a/libs/vue/migrations.json
+++ b/libs/vue/migrations.json
@@ -33,6 +33,15 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "11.0.0": {
+      "version": "11.0.0",
+      "packages": {
+        "eslint-plugin-vue": {
+          "version": "^7.8.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/libs/vue/src/migrations/update-11.0.0/update-11.0.0.ts
+++ b/libs/vue/src/migrations/update-11.0.0/update-11.0.0.ts
@@ -1,5 +1,9 @@
 import { chain, Rule } from '@angular-devkit/schematics';
-import { addDepsToPackageJson, readWorkspace } from '@nrwl/workspace';
+import {
+  addDepsToPackageJson,
+  readWorkspace,
+  updatePackagesInPackageJson,
+} from '@nrwl/workspace';
 import * as path from 'path';
 
 function deleteExtendInEslintConfig(): Rule {
@@ -28,6 +32,10 @@ function deleteExtendInEslintConfig(): Rule {
 
 export default function update(): Rule {
   return chain([
+    updatePackagesInPackageJson(
+      path.join(__dirname, '../../../', 'migrations.json'),
+      '11.0.0'
+    ),
     addDepsToPackageJson({}, { 'eslint-config-prettier': '8.1.0' }),
     deleteExtendInEslintConfig(),
   ]);

--- a/libs/vue/src/schematics/application/schematic.ts
+++ b/libs/vue/src/schematics/application/schematic.ts
@@ -374,7 +374,7 @@ export default function (options: ApplicationSchematicSchema): Rule {
             ? { '@vue/compiler-sfc': '^3.0.0' }
             : {}),
           '@vue/eslint-config-typescript': '^5.0.2',
-          'eslint-plugin-vue': normalizedOptions.isVue3 ? '^7.0.0-0' : '^6.2.2',
+          'eslint-plugin-vue': '^7.8.0',
           ...(!normalizedOptions.isVue3
             ? { 'vue-template-compiler': '^2.6.11' }
             : {}),

--- a/libs/vue/src/schematics/library/schematic.ts
+++ b/libs/vue/src/schematics/library/schematic.ts
@@ -343,7 +343,7 @@ export default function (options: LibrarySchematicSchema): Rule {
             ? { '@vue/compiler-sfc': '^3.0.0' }
             : {}),
           '@vue/eslint-config-typescript': '^5.0.2',
-          'eslint-plugin-vue': normalizedOptions.isVue3 ? '^7.0.0-0' : '^6.2.2',
+          'eslint-plugin-vue': '^7.8.0',
           ...(!normalizedOptions.isVue3
             ? { 'vue-template-compiler': '^2.6.11' }
             : {}),


### PR DESCRIPTION
## Current Behavior
Linting breaks inside a nuxt application if you install a vue lib. Steps to reproduce:
* yarn create-playground 
* nx g @nx-plus/nuxt:app my-app
* nx lint my-app -> 'All files pass linting'
* nx g @nx-plus/vue:lib my-lib
* nx lint my-app => 'Lint Errors...'

## Expected Behavior
Nuxt and Vue should play nice together when using both in one repo. Nuxt uses v7 of `eslint-plugin-vue` (as a dependency of `eslint-plugin-nuxt`). I believe after installing a vue lib, nuxt will resolve v6 that our vue schematic adds.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
