### PR TITLE
fix: patch-nx-dep-graph for windows

### DIFF
--- a/libs/vue/patch-nx-dep-graph.js
+++ b/libs/vue/patch-nx-dep-graph.js
@@ -7,7 +7,7 @@ const path = require('path');
  */
 function patchNxDepGraph() {
   const filePath = path.join(
-    process.env.INIT_CWD,
+    process.env.INIT_CWD || '',
     'node_modules/@nrwl/workspace/src/core/project-graph/build-dependencies/typescript-import-locator.js'
   );
   try {


### PR DESCRIPTION
on windows process.env.INIT_CWD is undefined, which makes the script fails because path.join expects strings
