### PR TITLE
fix docusaurus-e2e

### DIFF
--- a/apps/docusaurus-e2e/tests/docusaurus.test.ts
+++ b/apps/docusaurus-e2e/tests/docusaurus.test.ts
@@ -12,7 +12,7 @@ describe('docusaurus e2e', () => {
 
     const result = await runNxCommandAsync(`build ${appName}`);
     expect(result.stdout).toContain(
-      `Success! Generated static files in dist/apps/${appName}.`
+      `Success! Generated static files in "dist/apps/${appName}".`
     );
 
     done();


### PR DESCRIPTION
## Current Behavior
`docusaurus-e2e` is failing due to an update to the build output

## Expected Behavior
`docusaurus-e2e` is passing
