### PR TITLE
await resolveConfigureWebpack whenever called

### DIFF
--- a/libs/vue/src/executors/browser/executor.ts
+++ b/libs/vue/src/executors/browser/executor.ts
@@ -63,7 +63,7 @@ export default async function* runExecutor(
       filenameHashing: options.filenameHashing,
       productionSourceMap: options.productionSourceMap,
       css: options.css,
-      configureWebpack: resolveConfigureWebpack(projectRoot),
+      configureWebpack: await resolveConfigureWebpack(projectRoot),
       transpileDependencies: options.transpileDependencies,
     };
 

--- a/libs/vue/src/executors/dev-server/executor.ts
+++ b/libs/vue/src/executors/dev-server/executor.ts
@@ -113,7 +113,7 @@ export default async function* runExecutor(
     publicPath: browserOptions.publicPath,
     filenameHashing: browserOptions.filenameHashing,
     css: browserOptions.css,
-    configureWebpack: resolveConfigureWebpack(projectRoot),
+    configureWebpack: await resolveConfigureWebpack(projectRoot),
     devServer: options.devServer,
     transpileDependencies: options.transpileDependencies,
   };

--- a/libs/vue/src/executors/library/executor.ts
+++ b/libs/vue/src/executors/library/executor.ts
@@ -62,7 +62,7 @@ export default async function* runExecutor(
         }
       },
       css: options.css,
-      configureWebpack: resolveConfigureWebpack(projectRoot),
+      configureWebpack: await resolveConfigureWebpack(projectRoot),
     };
 
     checkUnsupportedConfig(context, projectRoot);


### PR DESCRIPTION
resolveConfigureWebpack is an async function that returns the promise of the
require statement. But all of the locations where resolveConfigureWebpack was
called, were not awaited. This meant that users of the plugin were not able to
install their own webpack configuration because the contents of configure-webpack.js
was never actually read and added to the vue-cli configuration object.

This commit adds the awaits for all of the locations where the function is called.
Unfortunately there are no unit tests that test these functions and I didn't know
how to go about adding unit tests for this area. So there are no new tests for
this change.

However, I believe it is important to get this out to users of the plugin quickly
because without this change the plugin is virtually useless for any substantial vue
app.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #233
