### PR TITLE
feat: add nx 13 support in dep-graph patchers

### DIFF
--- a/libs/nuxt/patch-nx-dep-graph.js
+++ b/libs/nuxt/patch-nx-dep-graph.js
@@ -6,11 +6,8 @@ const path = require('path');
  * @see https://github.com/nrwl/nx/issues/2960
  */
 function patchNxDepGraph() {
-  const filePath = path.join(
-    process.env.INIT_CWD || '',
-    'node_modules/@nrwl/workspace/src/core/project-graph/build-dependencies/typescript-import-locator.js'
-  );
   try {
+    const filePath = getFilePath();
     const fileContent = fs.readFileSync(filePath).toString('utf-8');
     const replacement = "extension !== '.ts' && extension !== '.vue'";
     if (fileContent.includes(replacement)) {
@@ -24,6 +21,22 @@ function patchNxDepGraph() {
   } catch (err) {
     console.error('Failed to patch Nx dep-graph for Vue support.', err);
   }
+}
+
+function getFilePath() {
+  const possiblePaths = [
+    'node_modules/nx/src/project-graph/build-dependencies/typescript-import-locator.js', // for Nx >= 13.10.3
+    'node_modules/@nrwl/workspace/src/core/project-graph/build-dependencies/typescript-import-locator.js', // for older versions of Nx
+  ];
+
+  for (const p of possiblePaths) {
+    const fullPath = path.join(process.env.INIT_CWD || '', p);
+    if (fs.existsSync(fullPath)) {
+      return fullPath;
+    }
+  }
+
+  throw new Error("Could not find Nx's dep-graph builder in node_modules");
 }
 
 patchNxDepGraph();

--- a/libs/vite/patch-nx-dep-graph.js
+++ b/libs/vite/patch-nx-dep-graph.js
@@ -6,11 +6,8 @@ const path = require('path');
  * @see https://github.com/nrwl/nx/issues/2960
  */
 function patchNxDepGraph() {
-  const filePath = path.join(
-    process.env.INIT_CWD || '',
-    'node_modules/@nrwl/workspace/src/core/project-graph/build-dependencies/typescript-import-locator.js'
-  );
   try {
+    const filePath = getFilePath();
     const fileContent = fs.readFileSync(filePath).toString('utf-8');
     const replacement = "extension !== '.ts' && extension !== '.vue'";
     if (fileContent.includes(replacement)) {
@@ -24,6 +21,22 @@ function patchNxDepGraph() {
   } catch (err) {
     console.error('Failed to patch Nx dep-graph for Vue support.', err);
   }
+}
+
+function getFilePath() {
+  const possiblePaths = [
+    'node_modules/nx/src/project-graph/build-dependencies/typescript-import-locator.js', // for Nx >= 13.10.3
+    'node_modules/@nrwl/workspace/src/core/project-graph/build-dependencies/typescript-import-locator.js', // for older versions of Nx
+  ];
+
+  for (const p of possiblePaths) {
+    const fullPath = path.join(process.env.INIT_CWD || '', p);
+    if (fs.existsSync(fullPath)) {
+      return fullPath;
+    }
+  }
+
+  throw new Error("Could not find Nx's dep-graph builder in node_modules");
 }
 
 patchNxDepGraph();

--- a/libs/vue/patch-nx-dep-graph.js
+++ b/libs/vue/patch-nx-dep-graph.js
@@ -6,11 +6,8 @@ const path = require('path');
  * @see https://github.com/nrwl/nx/issues/2960
  */
 function patchNxDepGraph() {
-  const filePath = path.join(
-    process.env.INIT_CWD || '',
-    'node_modules/@nrwl/workspace/src/core/project-graph/build-dependencies/typescript-import-locator.js'
-  );
   try {
+    const filePath = getFilePath();
     const fileContent = fs.readFileSync(filePath).toString('utf-8');
     const replacement = "extension !== '.ts' && extension !== '.vue'";
     if (fileContent.includes(replacement)) {
@@ -24,6 +21,22 @@ function patchNxDepGraph() {
   } catch (err) {
     console.error('Failed to patch Nx dep-graph for Vue support.', err);
   }
+}
+
+function getFilePath() {
+  const possiblePaths = [
+    'node_modules/nx/src/project-graph/build-dependencies/typescript-import-locator.js', // for Nx >= 13.10.3
+    'node_modules/@nrwl/workspace/src/core/project-graph/build-dependencies/typescript-import-locator.js', // for older versions of Nx
+  ];
+
+  for (const p of possiblePaths) {
+    const fullPath = path.join(process.env.INIT_CWD || '', p);
+    if (fs.existsSync(fullPath)) {
+      return fullPath;
+    }
+  }
+
+  throw new Error("Could not find Nx's dep-graph builder in node_modules");
 }
 
 patchNxDepGraph();


### PR DESCRIPTION
## Current Behavior
Running `npm run postinstall` throws this error with Nx `13.10.2:`

```
Failed to patch Nx dep-graph for Vue support. 
Error: ENOENT: no such file or directory, open
'/home/<stuff>/node_modules/@nrwl/workspace/src/core/project-graph/build-dependencies/typescript-import-locator.js'
```

## Expected Behavior
`npm run postinstall` should patch dep-graph builder function to support Vue files.

## Related Issue(s)

No issues, but it's an improved version of #246 

## N.B

The E2E tests are failing, but the last 2 commits on master failed at the same test so I don't think it's related to my PR.