### PR TITLE
ci: fix vite e2e tests

### DIFF
--- a/apps/vite-e2e/tests/vite.spec.ts
+++ b/apps/vite-e2e/tests/vite.spec.ts
@@ -28,9 +28,9 @@ describe('vite e2e', () => {
     await runNxCommandAsync(`build ${appName}`);
     checkFilesExist(
       `dist/apps/${appName}/index.html`,
+      `dist/apps/${appName}/favicon.ico`,
       `dist/apps/${appName}/assets/index.css`,
       `dist/apps/${appName}/assets/index.js`,
-      `dist/apps/${appName}/assets/vendor.js`,
       `dist/apps/${appName}/assets/logo.png`
     );
 


### PR DESCRIPTION
Fix vite e2e tests.

FYI, here are the files generated by vite:

![2022-05-17_10-44](https://user-images.githubusercontent.com/17952318/168770543-13ff2b25-1687-479c-99e0-025a60bcdac1.png)
