### PR TITLE
docs: updating packages version in the README

### DIFF
--- a/libs/vue/README.md
+++ b/libs/vue/README.md
@@ -23,7 +23,7 @@
 If you have not already, [create an Nx workspace](https://github.com/nrwl/nx#creating-an-nx-workspace) with the following:
 
 ```
-npx create-nx-workspace@^14.0.0
+npx create-nx-workspace@^14.3.6
 ```
 
 ### Peer Dependencies
@@ -32,10 +32,10 @@ If you have not already, install peer dependencies with the following:
 
 ```
 # npm
-npm install @nrwl/cypress@^14.0.0 @nrwl/jest@^14.0.0 @nrwl/linter@^14.0.0 --save-dev
+npm install @nrwl/cypress@^14.3.6 @nrwl/jest@^14.3.6 @nrwl/linter@^14.3.6 --save-dev
 
 # yarn
-yarn add @nrwl/cypress@^14.0.0 @nrwl/jest@^14.0.0 @nrwl/linter@^14.0.0 --dev
+yarn add @nrwl/cypress@^14.3.6 @nrwl/jest@^14.3.6 @nrwl/linter@^14.3.6 --dev
 ```
 
 ## Getting Started


### PR DESCRIPTION
## Current Behavior
With the current version written, there is an error when trying to create an app with `nx g @nx-plus/vue:app` : 
```
Cannot find module 'nx/src/config/configuration'
Require stack:
- some-project\node_modules\@nx-plus\vue\node_modules\@nrwl\devkit\index.js
- some-project\node_modules\@nx-plus\vue\src\generators\application\generator.js
- some-project\node_modules\nx\src\config\workspaces.js
- some-project\node_modules\nx\src\command-line\generate.js
- some-project\node_modules\nx\src\command-line\nx-commands.js
- some-project\node_modules\nx\bin\init-local.js
- some-project\node_modules\nx\bin\nx.js
- C:\Users\User\AppData\Roaming\nvm\v14.19.1\node_modules\nx\bin\nx.js
```
## Fixes
After using the the same commands with the last version of Nx used by the package, everything is working fine.