### PR TITLE
chore: bump @vue/cli-shared-utils

### DIFF
--- a/libs/vue/package.json
+++ b/libs/vue/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@nrwl/devkit": "^14.3.6",
-    "@vue/cli-shared-utils": "~4.5.15",
+    "@vue/cli-shared-utils": "~5.0.8",
     "copy-webpack-plugin": "^5.1.1",
     "fs-extra": "^10.0.0",
     "less": "^3.0.4",


### PR DESCRIPTION
## Current Behavior
Trying to install `@nx-plus/vue` fails with:
```
error @achrinza/node-ipc@9.2.2: The engine "node" is incompatible with this module. Expected version "8 || 10 || 12 || 14 || 16 || 17". Got "18.12.1"
error Found incompatible module.
```
on node >= 18. This is because `@vue/cli-shared-utils` hard relies on version `9.2.2` of  `@achrinza/node-ipc` which only supports node < 18.

## Expected Behavior
`@nx-plus/vue` should install on node >= 18 without errors.

## Fixes
Unfortunately, the newest 4.x version of `@vue/cli-shared-utils` also hard relies on `node-ipc@9.2.2`. So I bumped the shared utils package to `5.0.8`. Tests go through for me, but if the maintainers think that the package should stay on 4.x I can create a similiar PR on `@vue/cli-shared-utils` to bump node-ipc instead.
