### PR TITLE
feat(nuxt-port): issue #279 and similar to nx-plus/vue:serve

### DIFF
--- a/libs/nuxt/src/executors/server/executor.ts
+++ b/libs/nuxt/src/executors/server/executor.ts
@@ -57,7 +57,7 @@ export default async function* runExecutor(
     await build(nuxt);
   }
 
-  const result = await nuxt.listen(nuxt.options.server.port);
+  const result = await nuxt.listen(options.port || nuxt.options.server.port);
   const baseUrl = options.dev ? nuxt.server.listeners[0].url : result.url;
 
   logger.info(`\nListening on: ${baseUrl}\n`);

--- a/libs/nuxt/src/executors/server/schema.d.ts
+++ b/libs/nuxt/src/executors/server/schema.d.ts
@@ -2,4 +2,5 @@ export interface ServerExecutorSchema {
   browserTarget: string;
   watch: undefined;
   dev: boolean;
+  port: number;
 }

--- a/libs/nuxt/src/executors/server/schema.json
+++ b/libs/nuxt/src/executors/server/schema.json
@@ -19,6 +19,11 @@
       "type": "boolean",
       "description": "Define the development or production mode of Nuxt.js.",
       "default": true
+    },
+    "port": {
+      "type": "number",
+      "description": "Specify port (default: 8080).",
+      "default": 8080
     }
   },
   "required": ["browserTarget"],


### PR DESCRIPTION
## Current Behavior
The port have to be only set on `nuxt.config``

## Expected Behavior
Acts like `@nx-plus/vue:dev-server` receiving a port option

## Related Issue(s)
Pointed out at https://github.com/ZachJW34/nx-plus/issues/279

Fixes #
